### PR TITLE
Add Supabase audit logging for memberships and admin logins

### DIFF
--- a/app/(site)/admin/reports/page.tsx
+++ b/app/(site)/admin/reports/page.tsx
@@ -59,6 +59,15 @@ const reportGroups: ReportCardProps[] = [
     ],
   },
   {
+    title: 'Logs de plataforma',
+    summary:
+      'Descarga los registros generados por los inicios de sesión administrativos y las acciones del auditor de membresías.',
+    actions: [
+      { href: '/api/admin/reports/logs/login', label: 'Descargar log_acceso', description: 'CSV' },
+      { href: '/api/admin/reports/logs/membership-audit', label: 'Descargar log_auditoría', description: 'CSV' },
+    ],
+  },
+  {
     title: 'Resumen mensual',
     summary:
       'Accesos (OK/NOK/Unknown), nuevos socios y membresías no activas creadas por período YYYY-MM.',

--- a/app/api/admin/reports/logs/login/route.ts
+++ b/app/api/admin/reports/logs/login/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type LoginLogRow = {
+  fecha: string
+  email: string | null
+  usuario_id: string | null
+  exitoso: 'Sí' | 'No'
+  motivo_fallo: string | null
+  ip: string | null
+  user_agent: string | null
+}
+
+function toCsv(rows: Array<Record<string, unknown>>) {
+  if (!rows.length) return 'mensaje\nNo se encontraron registros.'
+  const header = Object.keys(rows[0])
+  const escape = (val: unknown) => {
+    if (val === null || val === undefined) return ''
+    const s = String(val)
+    const needsQuotes = /[",\n]/.test(s)
+    const escaped = s.replace(/"/g, '""')
+    return needsQuotes ? `"${escaped}"` : escaped
+  }
+  const csvRows = rows.map((row) => header.map((k) => escape(row[k])).join(','))
+  return [header.join(','), ...csvRows].join('\n')
+}
+
+function getServerClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  if (!url || !key) throw new Error('Faltan variables de entorno de Supabase.')
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+function parseDateRange(from?: string | null, to?: string | null) {
+  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
+  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
+  return { isoFrom, isoTo }
+}
+
+// GET /api/admin/reports/logs/login?from=YYYY-MM-DD&to=YYYY-MM-DD&limit=10000
+export async function GET(req: NextRequest) {
+  try {
+    const supabase = getServerClient()
+    const url = new URL(req.url)
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 10000, 50000)
+    const { isoFrom, isoTo } = parseDateRange(from, to)
+
+    let query = supabase
+      .from('login_logs')
+      .select('id, created_at, email, success, failure_reason, ip_address, user_agent, user_id')
+      .order('created_at', { ascending: false })
+      .limit(limit)
+
+    if (isoFrom) query = query.gte('created_at', isoFrom)
+    if (isoTo) query = query.lte('created_at', isoTo)
+
+    const { data, error } = await query
+    if (error) throw error
+
+    if (!data?.length) {
+      const csv = toCsv([])
+      const file = `log_acceso${from ? `_${from}` : ''}${to ? `_${to}` : ''}.csv`
+      return new Response(`\uFEFF${csv}`, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${file}"`,
+          'Cache-Control': 'no-store',
+        },
+      })
+    }
+
+    const rows: LoginLogRow[] = data.map((log) => ({
+      fecha: log.created_at,
+      email: log.email ?? null,
+      usuario_id: log.user_id ?? null,
+      exitoso: log.success ? 'Sí' : 'No',
+      motivo_fallo: log.success ? null : log.failure_reason ?? null,
+      ip: log.ip_address ?? null,
+      user_agent: log.user_agent ?? null,
+    }))
+
+    const csv = toCsv(rows)
+    const file = `log_acceso${from ? `_${from}` : ''}${to ? `_${to}` : ''}.csv`
+    return new Response(`\uFEFF${csv}`, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${file}"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err: any) {
+    const msg = err?.message ?? String(err)
+    return new Response(`error,detalle\ntrue,"${msg.replace(/"/g, '""')}"`, {
+      status: 500,
+      headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+    })
+  }
+}

--- a/app/api/admin/reports/logs/membership-audit/route.ts
+++ b/app/api/admin/reports/logs/membership-audit/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type AuditRow = {
+  fecha: string
+  accion: string
+  socio: string | null
+  atleta_id: string | null
+  membership_id: string | null
+  plan: string | null
+  periodo: string | null
+  estado_membresia: string | null
+  realizado_por: string | null
+  cambios: string | null
+}
+
+function toCsv(rows: Array<Record<string, unknown>>) {
+  if (!rows.length) return 'mensaje\nNo se encontraron registros.'
+  const header = Object.keys(rows[0])
+  const escape = (val: unknown) => {
+    if (val === null || val === undefined) return ''
+    const s = String(val)
+    const needsQuotes = /[",\n]/.test(s)
+    const escaped = s.replace(/"/g, '""')
+    return needsQuotes ? `"${escaped}"` : escaped
+  }
+  const csvRows = rows.map((row) => header.map((k) => escape(row[k])).join(','))
+  return [header.join(','), ...csvRows].join('\n')
+}
+
+function getServerClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  if (!url || !key) throw new Error('Faltan variables de entorno de Supabase.')
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+function parseDateRange(from?: string | null, to?: string | null) {
+  const isoFrom = from ? new Date(`${from}T00:00:00.000Z`).toISOString() : null
+  const isoTo = to ? new Date(`${to}T23:59:59.999Z`).toISOString() : null
+  return { isoFrom, isoTo }
+}
+
+// GET /api/admin/reports/logs/membership-audit?from=YYYY-MM-DD&to=YYYY-MM-DD&limit=10000
+export async function GET(req: NextRequest) {
+  try {
+    const supabase = getServerClient()
+    const url = new URL(req.url)
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 10000, 50000)
+    const { isoFrom, isoTo } = parseDateRange(from, to)
+
+    let query = supabase
+      .from('membership_audit_logs')
+      .select('id, membership_id, athlete_id, action, performed_by, changes, created_at')
+      .order('created_at', { ascending: false })
+      .limit(limit)
+
+    if (isoFrom) query = query.gte('created_at', isoFrom)
+    if (isoTo) query = query.lte('created_at', isoTo)
+
+    const { data, error } = await query
+    if (error) throw error
+
+    if (!data?.length) {
+      const csv = toCsv([])
+      const file = `log_auditoria${from ? `_${from}` : ''}${to ? `_${to}` : ''}.csv`
+      return new Response(`\uFEFF${csv}`, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${file}"`,
+          'Cache-Control': 'no-store',
+        },
+      })
+    }
+
+    const membershipIds = Array.from(new Set(data.map((row) => row.membership_id).filter(Boolean))) as string[]
+    const athleteIds = Array.from(new Set(data.map((row) => row.athlete_id).filter(Boolean))) as string[]
+
+    const membershipsById: Record<string, { plan: string | null; start_date: string | null; end_date: string | null; status: string | null }> = {}
+    if (membershipIds.length) {
+      const { data: memberships, error: membershipsError } = await supabase
+        .from('memberships')
+        .select('id, plan, start_date, end_date, status')
+        .in('id', membershipIds)
+      if (membershipsError) throw membershipsError
+      for (const membership of memberships ?? []) {
+        membershipsById[membership.id as string] = {
+          plan: membership.plan ?? null,
+          start_date: membership.start_date ?? null,
+          end_date: membership.end_date ?? null,
+          status: membership.status ?? null,
+        }
+      }
+    }
+
+    const athletesById: Record<string, string | null> = {}
+    if (athleteIds.length) {
+      const { data: athletes, error: athletesError } = await supabase
+        .from('athletes')
+        .select('id, name')
+        .in('id', athleteIds)
+      if (athletesError) throw athletesError
+      for (const athlete of athletes ?? []) {
+        athletesById[athlete.id as string] = athlete.name ?? null
+      }
+    }
+
+    const rows: AuditRow[] = data.map((log) => {
+      const membership = log.membership_id ? membershipsById[log.membership_id] : undefined
+      const periodo = membership?.start_date && membership?.end_date
+        ? `${membership.start_date} → ${membership.end_date}`
+        : null
+
+      return {
+        fecha: log.created_at,
+        accion: log.action,
+        socio: log.athlete_id ? athletesById[log.athlete_id] ?? null : null,
+        atleta_id: log.athlete_id ?? null,
+        membership_id: log.membership_id ?? null,
+        plan: membership?.plan ?? null,
+        periodo,
+        estado_membresia: membership?.status ?? null,
+        realizado_por: log.performed_by ?? null,
+        cambios: log.changes ? JSON.stringify(log.changes) : null,
+      }
+    })
+
+    const csv = toCsv(rows)
+    const file = `log_auditoria${from ? `_${from}` : ''}${to ? `_${to}` : ''}.csv`
+    return new Response(`\uFEFF${csv}`, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${file}"`,
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err: any) {
+    const msg = err?.message ?? String(err)
+    return new Response(`error,detalle\ntrue,"${msg.replace(/"/g, '""')}"`, {
+      status: 500,
+      headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+    })
+  }
+}

--- a/app/api/logs/login/route.ts
+++ b/app/api/logs/login/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+type Body = {
+  email?: string
+  success?: boolean
+  userId?: string | null
+  failureReason?: string | null
+  userAgent?: string | null
+}
+
+function getServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    throw new Error('Faltan variables de entorno de Supabase para registrar logins.')
+  }
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as Body
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : null
+    const success = typeof body.success === 'boolean' ? body.success : null
+    const userId = body.userId && typeof body.userId === 'string' ? body.userId : null
+    const failureReason = typeof body.failureReason === 'string' ? body.failureReason : null
+    const uaFromBody = typeof body.userAgent === 'string' ? body.userAgent : null
+
+    if (success === null) {
+      return NextResponse.json({ ok: false, error: 'Parámetro "success" es requerido.' }, { status: 400 })
+    }
+
+    const supabase = getServiceClient()
+    const forwardedFor = req.headers.get('x-forwarded-for') ?? undefined
+    const ip = forwardedFor ? forwardedFor.split(',')[0]?.trim() ?? null : null
+    const userAgent = uaFromBody ?? req.headers.get('user-agent') ?? null
+
+    const { error } = await supabase.from('login_logs').insert({
+      email,
+      success,
+      user_id: userId,
+      failure_reason: failureReason,
+      ip_address: ip,
+      user_agent: userAgent,
+    })
+
+    if (error) throw error
+
+    return NextResponse.json({ ok: true })
+  } catch (err: any) {
+    console.error('[login log] error', err)
+    const message = err?.message ?? 'No se pudo registrar el login'
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add Supabase tables and trigger to persist audit logs for membership changes
- create API endpoint and client helper to store admin login attempts with metadata
- record login attempts from the admin sign-in form without interrupting the flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7207b8edc832eb5c0dc8f5ddc39b7