### PR TITLE
Add athlete photo management and kiosk display

### DIFF
--- a/app/api/access/validate/route.ts
+++ b/app/api/access/validate/route.ts
@@ -1,6 +1,7 @@
 // app/api/access/validate/route.ts
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { ATHLETE_PHOTOS_BUCKET } from '@/lib/athletePhotos'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -11,6 +12,7 @@ type AthleteLite = {
   name: string | null
   email?: string | null
   phone?: string | null
+  photo_path?: string | null
 }
 
 type CardWithAthlete = {
@@ -55,7 +57,7 @@ export async function POST(req: NextRequest) {
         uid,
         active,
         athlete_id,
-        athletes:athletes ( name, email, phone )
+        athletes:athletes ( name, email, phone, photo_path )
       `)
       .eq('uid', cleanedUID)
       .eq('active', true)
@@ -64,7 +66,7 @@ export async function POST(req: NextRequest) {
 
     let result: AccessResult
     let note = ''
-    let athlete: { id?: string; name?: string | null } | null = null
+    let athlete: { id?: string; name?: string | null; photo_url?: string | null } | null = null
     let membership: { plan?: string | null; end_date?: string | null } | null = null
 
     if (!card) {
@@ -74,7 +76,11 @@ export async function POST(req: NextRequest) {
     } else {
       const athleteRel = card.athletes
       const athleteObj = Array.isArray(athleteRel) ? athleteRel[0] : athleteRel
-      athlete = { id: card.athlete_id, name: athleteObj?.name ?? null }
+      const photoPath = (athleteObj as AthleteLite | undefined)?.photo_path ?? null
+      const photoUrl = photoPath
+        ? supabase.storage.from(ATHLETE_PHOTOS_BUCKET).getPublicUrl(photoPath).data?.publicUrl ?? null
+        : null
+      athlete = { id: card.athlete_id, name: athleteObj?.name ?? null, photo_url: photoUrl }
 
       // 2) Buscar membresías del atleta y evaluar vigencia
       const { data: mems, error: memErr } = await supabase

--- a/lib/athletePhotos.ts
+++ b/lib/athletePhotos.ts
@@ -1,0 +1,43 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { inferImageExtension, resolveImageContentType } from './imageHelpers'
+
+export const ATHLETE_PHOTOS_BUCKET = 'athlete-photos'
+
+export function buildAthletePhotoPath(athleteId: string, extension: string) {
+  const safeExt = extension.replace(/[^a-z0-9]/gi, '').toLowerCase() || 'jpg'
+  const version = Date.now()
+  return `${athleteId}/profile-${version}.${safeExt}`
+}
+
+export async function uploadAthletePhoto(
+  client: SupabaseClient,
+  athleteId: string,
+  file: File,
+): Promise<string> {
+  const extension = inferImageExtension(file)
+  const path = buildAthletePhotoPath(athleteId, extension)
+  const contentType = resolveImageContentType(file, extension)
+
+  const { error } = await client.storage.from(ATHLETE_PHOTOS_BUCKET).upload(path, file, {
+    cacheControl: '3600',
+    upsert: true,
+    contentType,
+  })
+
+  if (error) {
+    throw error
+  }
+
+  return path
+}
+
+export async function removeAthletePhoto(client: SupabaseClient, path?: string | null) {
+  if (!path) return
+  await client.storage.from(ATHLETE_PHOTOS_BUCKET).remove([path])
+}
+
+export function getAthletePhotoPublicUrl(client: SupabaseClient, path?: string | null): string {
+  if (!path) return ''
+  const { data } = client.storage.from(ATHLETE_PHOTOS_BUCKET).getPublicUrl(path)
+  return data?.publicUrl ?? ''
+}

--- a/lib/imageHelpers.ts
+++ b/lib/imageHelpers.ts
@@ -1,0 +1,35 @@
+export function sanitizeExtension(raw?: string | null): string | undefined {
+  if (!raw) return undefined
+  const value = raw.trim().toLowerCase().replace(/[^a-z0-9]/g, '')
+  return value || undefined
+}
+
+export function inferImageExtension(file: File): string {
+  const nameExt = file.name.includes('.') ? file.name.split('.').pop() ?? null : null
+  const fromName = sanitizeExtension(nameExt)
+  if (fromName) return fromName === 'jpeg' ? 'jpg' : fromName
+
+  const typeExt = file.type.includes('/') ? file.type.split('/').pop() ?? null : null
+  const fromType = sanitizeExtension(typeExt)
+  if (fromType) return fromType === 'jpeg' ? 'jpg' : fromType
+
+  return 'jpg'
+}
+
+export function resolveImageContentType(file: File, extension: string): string {
+  if (file.type) return file.type
+
+  switch (extension) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'png':
+      return 'image/png'
+    case 'webp':
+      return 'image/webp'
+    case 'gif':
+      return 'image/gif'
+    default:
+      return 'application/octet-stream'
+  }
+}

--- a/public/images/athlete-placeholder.svg
+++ b/public/images/athlete-placeholder.svg
@@ -1,0 +1,5 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="128" fill="#E5E7EB"/>
+  <circle cx="128" cy="96" r="48" fill="#9CA3AF"/>
+  <path d="M48 220C57 174 89 148 128 148C167 148 199 174 208 220" stroke="#9CA3AF" stroke-width="20" stroke-linecap="round"/>
+</svg>

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -10,6 +10,7 @@ create table if not exists public.athletes (
   birthdate date,
   email text,
   phone text,
+  photo_path text,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- add storage helpers and schema column to persist optional athlete photos
- extend athlete create/edit flows to upload, replace, or remove pictures while cleaning Supabase storage
- surface photos in kiosk access results with a shared placeholder when no image exists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d74c6c06d0832ebdd2578a7017f7fa