### PR TITLE
Add athlete photo support and display in kiosk

### DIFF
--- a/lib/athletePhotos.ts
+++ b/lib/athletePhotos.ts
@@ -1,0 +1,61 @@
+export const ATHLETE_PHOTO_BUCKET = 'athlete-photos'
+export const ATHLETE_PHOTO_FOLDER = 'athletes'
+
+const VALID_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif'] as const
+export type AthletePhotoExtension = (typeof VALID_EXTENSIONS)[number]
+
+type NullableString = string | null | undefined
+
+export function sanitizePhotoExtension(raw: NullableString): AthletePhotoExtension | null {
+  if (!raw) return null
+  const cleaned = raw.trim().toLowerCase().replace(/[^a-z0-9]/g, '')
+  if (!cleaned) return null
+  const normalized = cleaned === 'jpeg' ? 'jpg' : cleaned
+  return (VALID_EXTENSIONS as readonly string[]).includes(normalized)
+    ? (normalized as AthletePhotoExtension)
+    : null
+}
+
+export function inferPhotoExtension(file: File): AthletePhotoExtension {
+  const namePart = file.name?.includes('.') ? file.name.split('.').pop() : null
+  const fromName = sanitizePhotoExtension(namePart)
+  if (fromName) return fromName
+
+  const typePart = file.type?.includes('/') ? file.type.split('/').pop() : null
+  const fromType = sanitizePhotoExtension(typePart)
+  if (fromType) return fromType
+
+  return 'jpg'
+}
+
+export function resolvePhotoContentType(file: File, extension: AthletePhotoExtension) {
+  if (file.type) return file.type
+
+  switch (extension) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'png':
+      return 'image/png'
+    case 'webp':
+      return 'image/webp'
+    case 'gif':
+      return 'image/gif'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+export function buildAthletePhotoPath(athleteId: string, extension: AthletePhotoExtension) {
+  const safeExt = sanitizePhotoExtension(extension) ?? 'jpg'
+  const timestamp = Date.now()
+  return `${ATHLETE_PHOTO_FOLDER}/${athleteId}/${timestamp}.${safeExt}`
+}
+
+export function buildAthletePhotoPublicUrl(path?: NullableString) {
+  if (!path) return null
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (!base) return null
+  const normalizedBase = base.replace(/\/+$/, '')
+  return `${normalizedBase}/storage/v1/object/public/${ATHLETE_PHOTO_BUCKET}/${path}`
+}

--- a/public/images/athlete-placeholder.svg
+++ b/public/images/athlete-placeholder.svg
@@ -1,0 +1,12 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Imagen genérica de deportista">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e5e7eb" />
+      <stop offset="100%" stop-color="#d1d5db" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="128" fill="url(#bg)" />
+  <circle cx="128" cy="100" r="60" fill="#cbd5f5" />
+  <path d="M64 224c0-40 32-72 72-72s72 32 72 72" fill="#a5b4fc" />
+  <path d="M128 36c-28 0-52 24-52 52 0 6 1 12 3 18 8 4 24 10 49 10s41-6 49-10a52 52 0 0 0 3-18c0-28-24-52-52-52z" fill="#818cf8" opacity="0.4" />
+</svg>

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -10,8 +10,15 @@ create table if not exists public.athletes (
   birthdate date,
   email text,
   phone text,
+  photo_path text,
   created_at timestamptz default now()
 );
+
+-- Bucket público para las fotos de deportistas
+insert into storage.buckets (id, name, public)
+values ('athlete-photos', 'athlete-photos', true)
+on conflict (id) do nothing;
+
 
 create table if not exists public.cards (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- allow admins to upload, replace or remove optional athlete photos during creation and editing, storing files in a dedicated bucket
- surface athlete photo URLs through the access validation API and show pictures in the kiosk UI with a fallback placeholder
- document the new `photo_path` column and storage bucket plus add a default placeholder asset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d74c6c06d0832ebdd2578a7017f7fa