### PR TITLE
Fix athlete deletion FK issue

### DIFF
--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -139,7 +139,11 @@ begin
     athlete := NEW.athlete_id;
   elsif (TG_OP = 'DELETE') then
     payload := jsonb_build_object('old', to_jsonb(OLD));
-    membership := OLD.id;
+    -- Cuando eliminamos la membresía el registro original ya no existe,
+    -- por lo que el FK en membership_audit_logs no puede apuntar a él.
+    -- Guardamos el snapshot completo en "changes" y dejamos el FK en NULL
+    -- para evitar violaciones al eliminar atletas.
+    membership := null;
     athlete := OLD.athlete_id;
   else
     return null;


### PR DESCRIPTION
## Summary
- avoid membership audit FK violations by keeping membership_id null on delete logs
- enrich membership audit CSV export with data from the stored snapshot when membership is gone

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3091d4628832e96e0e32a78e539a5