### PR TITLE
Fix default membership status when creating athletes

### DIFF
--- a/app/(site)/admin/athletes/new/page.tsx
+++ b/app/(site)/admin/athletes/new/page.tsx
@@ -110,7 +110,7 @@ export default function AthleteNewPage() {
           plan,
           start_date: start,
           end_date: end,
-          status: 'activo'
+          status: 'active'
         })
       if (mErr) throw mErr
 


### PR DESCRIPTION
## Summary
- set the created membership status to the valid `active` value when registering a new athlete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e31858cdd0832e8962df1f80a3129d