### PR TITLE
Add cron endpoint to refresh membership statuses daily and manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Copia `.env.example` a `.env.local` y completa según el entorno.
 | `NEXT_PUBLIC_SUPABASE_URL` | URL del proyecto Supabase (Project settings → API). |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Clave pública para operaciones desde el cliente. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Clave **service role** usada por APIs protegidas (solo servidor). |
+| `MEMBERSHIP_STATUS_CRON_SECRET` | Token secreto que debe acompañar la llamada diaria a `/api/cron/memberships/status`. |
+| `MEMBERSHIP_STATUS_TIMEZONE` | (Opcional) Zona horaria para calcular el “hoy” efectivo al sincronizar estados (por defecto `UTC`). |
 | `NEXT_PUBLIC_SITE_URL` | URL base del sitio (ej. `http://localhost:3000`). |
 | `NEXT_PUBLIC_API_BASE_URL` | (Opcional) Base URL de una API propia si utilizas `lib/api.ts`. |
 | `API_PUBLIC_TOKEN` | (Opcional) Token Bearer público para las peticiones anteriores. |
@@ -89,6 +91,13 @@ La aplicación se levanta en `http://localhost:3000`. Las rutas públicas (home,
 | `npm run build` | Genera el build de producción (`.next`). |
 | `npm run start` | Sirve el build generado. |
 | `npm run lint` | Ejecuta el wrapper que intenta resolver `next lint`; si la dependencia `eslint-config-next` no está instalada localmente, el script finaliza sin error (el pipeline de CI la instala automáticamente). |
+
+### Actualización automática de estados de membresía
+
+- El endpoint protegido `/api/cron/memberships/status` marca automáticamente como **expiradas** las membresías cuya `end_date` ya pasó y re-activa aquellas que vuelven a quedar vigentes.
+- Configura la variable `MEMBERSHIP_STATUS_CRON_SECRET` (o alternativamente `CRON_SECRET`) y agenda una tarea diaria en tu plataforma (Vercel Cron Jobs, GitHub Actions, Supabase Scheduler, etc.) que invoque `POST https://tu-dominio/api/cron/memberships/status` con el encabezado `Authorization: Bearer <secreto>` o el query param `?token=<secreto>`.
+- (Opcional) Define `MEMBERSHIP_STATUS_TIMEZONE` con la zona horaria local del gimnasio (por ejemplo `America/Santiago`) para que el corte diario ocurra en horario local.
+- También puedes lanzar la sincronización manualmente desde `/admin/athletes` con el botón **Actualizar estados**, ideal para reflejar cambios inmediatos después de editar planes.
 
 ## Estructura relevante
 ```

--- a/app/(site)/admin/athletes/actions.ts
+++ b/app/(site)/admin/athletes/actions.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { refreshMembershipStatuses } from '@/lib/memberships/status'
+import { getSupabaseServer } from '@/lib/supabaseServer'
+import { MissingServiceRoleConfigError } from '@/lib/supabase/service-role'
+import type { RefreshMembershipStatusesResult } from '@/lib/memberships/status'
+
+export type ManualRefreshResponse =
+  | { ok: true; result: RefreshMembershipStatusesResult }
+  | { ok: false; error: string }
+
+export async function runMembershipStatusRefresh(): Promise<ManualRefreshResponse> {
+  try {
+    const supabase = getSupabaseServer()
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+
+    if (!session) {
+      return { ok: false, error: 'Debes iniciar sesión para actualizar el estado de las membresías.' }
+    }
+
+    const result = await refreshMembershipStatuses()
+    return { ok: true, result }
+  } catch (error: unknown) {
+    if (error instanceof MissingServiceRoleConfigError) {
+      return {
+        ok: false,
+        error:
+          'Faltan las llaves service-role de Supabase. Configura NEXT_PUBLIC_SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY.',
+      }
+    }
+
+    const message = error instanceof Error ? error.message : 'No fue posible completar la actualización.'
+    return { ok: false, error: message }
+  }
+}

--- a/app/(site)/admin/athletes/page.tsx
+++ b/app/(site)/admin/athletes/page.tsx
@@ -5,13 +5,46 @@ export const dynamic = 'force-dynamic'
 import AthletesClient from './table-client'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+import { runMembershipStatusRefresh } from './actions'
+
+type BannerState =
+  | { type: 'success'; message: string }
+  | { type: 'error'; message: string }
+  | null
 
 export default function AthletesPage() {
   const router = useRouter()
+  const [banner, setBanner] = useState<BannerState>(null)
+  const [reloadSignal, setReloadSignal] = useState(0)
+  const [refreshing, startRefresh] = useTransition()
+
+  const handleRefresh = () => {
+    setBanner(null)
+    startRefresh(async () => {
+      const response = await runMembershipStatusRefresh()
+      if (!response.ok) {
+        setBanner({ type: 'error', message: response.error })
+        return
+      }
+
+      const { result } = response
+      const summary =
+        result.markedExpired || result.markedActive
+          ? `Expiradas: ${result.markedExpired} · Reactivadas: ${result.markedActive}`
+          : 'No hubo cambios en los planes.'
+
+      setBanner({
+        type: 'success',
+        message: `Actualización ejecutada (${summary}). Corte: ${result.effectiveDate} (${result.timeZone}).`,
+      })
+      setReloadSignal((value) => value + 1)
+    })
+  }
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
         <button
           onClick={() => router.back()}
           className="text-sm underline"
@@ -21,16 +54,38 @@ export default function AthletesPage() {
 
         <h1 className="text-2xl font-bold flex-1 text-center">Atletas</h1>
 
-        <Link
-          href="/admin/athletes/new"
-          className="inline-flex items-center justify-center rounded-lg bg-black text-white px-4 py-2 hover:bg-black/80"
-        >
-          Nuevo deportista
-        </Link>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="inline-flex items-center justify-center rounded-lg border border-black px-4 py-2 text-sm font-medium hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {refreshing ? 'Actualizando…' : 'Actualizar estados'}
+          </button>
+
+          <Link
+            href="/admin/athletes/new"
+            className="inline-flex items-center justify-center rounded-lg bg-black text-white px-4 py-2 hover:bg-black/80"
+          >
+            Nuevo deportista
+          </Link>
+        </div>
       </div>
 
+      {banner && (
+        <div
+          className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
+            banner.type === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+              : 'border-red-200 bg-red-50 text-red-800'
+          }`}
+        >
+          {banner.message}
+        </div>
+      )}
+
       <div className="mt-4">
-        <AthletesClient />
+        <AthletesClient reloadSignal={reloadSignal} />
       </div>
     </main>
   )

--- a/app/(site)/admin/athletes/table-client.tsx
+++ b/app/(site)/admin/athletes/table-client.tsx
@@ -15,7 +15,7 @@ type AthleteRow = {
   memberships: EmbeddedMembership[] | null
 }
 
-export default function AthletesClient() {
+export default function AthletesClient({ reloadSignal = 0 }: { reloadSignal?: number }) {
   const [rows, setRows] = useState<AthleteRow[]>([])
   const [q, setQ] = useState('')
   const [loading, setLoading] = useState(false)
@@ -73,7 +73,7 @@ export default function AthletesClient() {
     }
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => { load() }, [reloadSignal])
 
   return (
     <div className="grid gap-4">

--- a/app/api/cron/memberships/status/route.ts
+++ b/app/api/cron/memberships/status/route.ts
@@ -1,0 +1,65 @@
+// app/api/cron/memberships/status/route.ts
+import { NextRequest } from 'next/server'
+import { refreshMembershipStatuses } from '@/lib/memberships/status'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type HandlerResult = Response | Promise<Response>
+
+function extractToken(req: NextRequest): string | null {
+  const auth = req.headers.get('authorization')
+  if (auth) {
+    const [scheme, value] = auth.split(' ')
+    if (scheme?.toLowerCase() === 'bearer' && value) {
+      return value.trim()
+    }
+  }
+
+  const headerSecret = req.headers.get('x-cron-secret')
+  if (headerSecret) {
+    return headerSecret.trim()
+  }
+
+  const url = new URL(req.url)
+  const queryToken = url.searchParams.get('token') ?? url.searchParams.get('secret')
+  if (queryToken) {
+    return queryToken.trim()
+  }
+
+  return null
+}
+
+async function handler(req: NextRequest): Promise<Response> {
+  const expected = process.env.MEMBERSHIP_STATUS_CRON_SECRET ?? process.env.CRON_SECRET ?? ''
+  if (!expected) {
+    return Response.json(
+      { ok: false, error: 'Cron secret not configured.' },
+      { status: 500 },
+    )
+  }
+
+  const provided = extractToken(req)
+  if (!provided || provided !== expected) {
+    return Response.json(
+      { ok: false, error: 'Unauthorized' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    const result = await refreshMembershipStatuses()
+    return Response.json({ ok: true, result })
+  } catch (err: any) {
+    const message = err?.message ?? 'Unexpected error'
+    return Response.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export function GET(req: NextRequest): HandlerResult {
+  return handler(req)
+}
+
+export function POST(req: NextRequest): HandlerResult {
+  return handler(req)
+}

--- a/lib/memberships/status.ts
+++ b/lib/memberships/status.ts
@@ -1,0 +1,62 @@
+// lib/memberships/status.ts
+import { getServiceRoleClient } from '@/lib/supabase/service-role'
+
+type RefreshOptions = {
+  referenceDate?: Date
+  timeZone?: string
+}
+
+export type RefreshMembershipStatusesResult = {
+  referenceDate: string
+  effectiveDate: string
+  timeZone: string
+  markedExpired: number
+  markedActive: number
+}
+
+function getEffectiveDate(options?: RefreshOptions): { today: string; timeZone: string; reference: Date } {
+  const reference = options?.referenceDate ?? new Date()
+  const timeZone = options?.timeZone ?? process.env.MEMBERSHIP_STATUS_TIMEZONE ?? 'UTC'
+
+  const formatter = new Intl.DateTimeFormat('en-CA', { timeZone })
+  const today = formatter.format(reference)
+
+  return { today, timeZone, reference }
+}
+
+export async function refreshMembershipStatuses(options?: RefreshOptions): Promise<RefreshMembershipStatusesResult> {
+  const supabase = getServiceRoleClient()
+
+  const { today, timeZone, reference } = getEffectiveDate(options)
+
+  const { data: expired, error: expireErr } = await supabase
+    .from('memberships')
+    .update({ status: 'expired' })
+    .lt('end_date', today)
+    .in('status', ['active', 'sold'])
+    .select('id')
+
+  if (expireErr) {
+    throw expireErr
+  }
+
+  const { data: activated, error: activateErr } = await supabase
+    .from('memberships')
+    .update({ status: 'active' })
+    .lte('start_date', today)
+    .gte('end_date', today)
+    .in('status', ['expired', 'sold'])
+    .select('id')
+
+  if (activateErr) {
+    throw activateErr
+  }
+
+  return {
+    referenceDate: reference.toISOString(),
+    effectiveDate: today,
+    timeZone,
+    markedExpired: expired?.length ?? 0,
+    markedActive: activated?.length ?? 0,
+  }
+}


### PR DESCRIPTION
## Summary
- add a service-role helper that recalculates membership statuses based on the current date
- expose a secured cron endpoint that runs the refresh once per day via an external scheduler
- document the required environment variables and setup steps for the automated job
- add a manual membership refresh button on the athletes admin page that uses a server action and reloads the athlete table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5928d28c0832e9fa7f11c6ec78821